### PR TITLE
[FHDDS] Service Unavailable

### DIFF
--- a/app/uk/gov/hmrc/fhregistration/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/fhregistration/connectors/DesConnector.scala
@@ -77,7 +77,7 @@ class DefaultDesConnector @Inject() (
   private[connectors] def customDESRead(response: HttpResponse): HttpResponse =
     response.status match {
       case 403 =>
-        logger.error(s"Received error 403 from DES with message - ${response.json}")
+        logger.error(s"Received error 403 from DES with message - ${response.body}")
         response
       case 429 =>
         logger.error("[RATE LIMITED] Received 429 from DES - converting to 503")


### PR DESCRIPTION
Based on this [ticket:](https://jira.tools.tax.service.gov.uk/browse/DLS-11012) we got 500 error from DES which we should handle that error nicely in our side so we change `response.json` to` response.body` that should not throw an exception so we can handle error better in our side.